### PR TITLE
do join with invalid name

### DIFF
--- a/src/gulp-tasks/src/css/compile.js
+++ b/src/gulp-tasks/src/css/compile.js
@@ -39,7 +39,7 @@ export default class LessCompile extends Base {
 
         this.logger.updated({
           src: src,
-          dest: join(dest, name)
+          dest: name ? join(dest, name) : dest
         });
       });
   }


### PR DESCRIPTION
It should be possible to compile styles into separate files. It can be done by specifying directory for "dest" option:
````
css:
  src:
    - less/one.less
    - less/two.less
  dest: ui/
 ````

Everything is working fine except logger.